### PR TITLE
Get timesheets for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,28 @@ Set the environment variable `NODE_TSHEETS_API_CLIENT_TOKEN` to a TSheets access
 ### `reportTime(params, callback)`
 
 Reports time for a user, using the provided job code.
- 
+
 **Params**
 
-| Parameter | Description | Type | Required |
-| --- | --- | --- | --- |
-| api_token | TSheets API token to use for the request. | string | Yes |
-| user_id | ID of TSheets user to report time for. | number | Yes |
-| jobcode_id | TSheets job code ID. | number | Yes |
-| duration_seconds | Total seconds to report on job code. | number | Yes |
-| date | `YYYY-MM-DD` for the date to report time for. | string | Yes |
+| Parameter        | Description                                   | Type   | Required |
+|------------------|-----------------------------------------------|--------|----------|
+| api_token        | TSheets API token to use for the request.     | string | Yes      |
+| user_id          | ID of TSheets user to report time for.        | number | Yes      |
+| jobcode_id       | TSheets job code ID.                          | number | Yes      |
+| duration_seconds | Total seconds to report on job code.          | number | Yes      |
+| date             | `YYYY-MM-DD` for the date to report time for. | string | Yes      |
+
+
+
+### `getTimesheets(params, callback)`
+
+Gets timesheets for the specified user(s) for the provided time period.
+
+**Params**
+
+| Parameter  | Description                                      | Type     | Required |
+|------------|--------------------------------------------------|----------|----------|
+| api_token  | TSheets API token to use for the request.        | string   | Yes      |
+| start_date | `YYYY-MM-DD` for the starting date.              | string   | Yes      |
+| end_date   | `YYYY-MM-DD` for the end date.                   | string   | Yes      |
+| user_ids   | Array of TSheets user IDs to get timesheets for. | number[] | No       |

--- a/lib/tsheets-api.js
+++ b/lib/tsheets-api.js
@@ -11,7 +11,8 @@ var internals = {
     api_token: joi.string().required(),
     endpoint: joi.string().required(),
     method: joi.string().required(),
-    body_params: joi.any().optional()
+    body_params: joi.any().optional(),
+    qs: joi.object().optional()
   })
 };
 
@@ -64,10 +65,14 @@ internals.getRequestOptions = function(valid_params) {
     }
   };
 
-  if (Object.keys(valid_params.body_params).length) {
+  if (valid_params.body_params && Object.keys(valid_params.body_params).length) {
     opts.json = {
       data: valid_params.body_params
     };
+  }
+
+  if (valid_params.qs) {
+    opts.qs = valid_params.qs;
   }
 
   return opts;

--- a/lib/tsheets-service.js
+++ b/lib/tsheets-service.js
@@ -12,18 +12,35 @@ var internals = {
     jobcode_id: joi.number().required(),
     duration_seconds: joi.number().required(),
     date: joi.string().required()
+  }),
+
+  get_timesheets_validation_schema: joi.object().required().keys({
+    api_token: joi.string().required(),
+    start_date: joi.string().required(),
+    end_date: joi.string().required(),
+    user_ids: joi.array().includes(joi.number()).optional()
   })
 };
 
 
 /**
- * Reports time for a user in a job code.
- *
+ * @see reportTime
  * @type {Function}
- * @param {Object} params To be validated: api_token, jobcode_id, user_id, duration_seconds, date.
- * @param {Function} callback Invoked with [err, result].
  */
-exports.reportTime = function(params, callback) {
+exports.reportTime = reportTime;
+
+
+/**
+ * @see getTimesheets
+ * @type {Function}
+ */
+exports.getTimesheets = getTimesheets;
+
+
+// Private implementation
+
+
+function reportTime(params, callback) {
   var validated_params,
       req_params;
 
@@ -37,7 +54,24 @@ exports.reportTime = function(params, callback) {
 
   req_params = internals.createReportTimeRequestParams(validated_params);
   api_service.makeRequest(req_params, callback);
-};
+}
+
+
+function getTimesheets(params, callback) {
+  var validated_params,
+      req_params;
+
+  try {
+    validated_params = internals.validateGetTimesheetsParams(params);
+  }
+  catch (e) {
+    setImmediate(callback, e);
+    return;
+  }
+
+  req_params = internals.createGetTimesheetsParams(validated_params);
+  api_service.makeRequest(req_params, callback);
+}
 
 
 internals.validateReportTimeParams = function(params) {
@@ -60,6 +94,29 @@ internals.createReportTimeRequestParams = function(valid_params) {
       }
     ]
   };
+};
+
+internals.validateGetTimesheetsParams = function(params) {
+  return validator.validateParams(params, internals.get_timesheets_validation_schema);
+};
+
+
+internals.createGetTimesheetsParams = function(valid_params) {
+  var params = {
+    api_token: valid_params.api_token,
+    method: 'get',
+    endpoint: '/timesheets',
+    qs: {
+      start_date: valid_params.start_date,
+      end_date: valid_params.end_date
+    }
+  };
+
+  if (Array.isArray(valid_params.user_ids) && valid_params.user_ids.length) {
+    params.qs.user_ids = valid_params.user_ids;
+  }
+
+  return params;
 };
 
 

--- a/test/tsheets-api-test.js
+++ b/test/tsheets-api-test.js
@@ -14,7 +14,7 @@ describe(__filename, function() {
         var params;
 
         beforeEach(function() {
-          params = internals.createReportTimeParams();
+          params = internals.getCurrentUserParams();
         });
 
         it('should return a response object', function(done) {
@@ -31,7 +31,7 @@ describe(__filename, function() {
         var params;
 
         beforeEach(function() {
-          params = internals.createReportTimeParams();
+          params = internals.getCurrentUserParams();
           params.api_token = 'foo';
         });
 
@@ -72,7 +72,7 @@ describe(__filename, function() {
       var params;
 
       beforeEach(function() {
-        params = internals.createReportTimeParams();
+        params = internals.getCurrentUserParams();
         params.body_params = {
           foo: 'bar'
         };
@@ -100,7 +100,7 @@ describe(__filename, function() {
 });
 
 
-internals.createReportTimeParams = function() {
+internals.getCurrentUserParams = function() {
   return {
     endpoint: '/current_user',
     method: 'get',
@@ -111,7 +111,7 @@ internals.createReportTimeParams = function() {
 
 
 internals.assertMissingParamFailsValidation = function(param_name) {
-  var params = internals.createReportTimeParams();
+  var params = internals.getCurrentUserParams();
   delete params[param_name];
 
   (function() {

--- a/test/tsheets-client-test.js
+++ b/test/tsheets-client-test.js
@@ -13,6 +13,11 @@ describe(__filename, function() {
       tsheets_client.reportTime.should.be.a('function');
     });
 
+    it('should define getTimesheets()', function() {
+      tsheets_client.should.have.property('getTimesheets');
+      tsheets_client.getTimesheets.should.be.a('function');
+    });
+
   });
 
 });

--- a/test/tsheets-service-test.js
+++ b/test/tsheets-service-test.js
@@ -12,84 +12,207 @@ describe(__filename, function() {
 
   describe('reportTime', function() {
 
-    describe('with valid params', function() {
-      var params;
+    describe('exports.reportTime', function() {
 
-      beforeEach(function() {
-        params = internals.createReportTimeParams();
-      });
+      describe('with valid params', function() {
+        var params;
 
-      it('should invoke API without error', function(done) {
-        service.reportTime(params, function(err, result) {
-          should.not.exist(err);
-          should.exist(result);
-          done();
+        beforeEach(function() {
+          params = internals.createReportTimeParams();
         });
-      });
 
-    });
-
-  });
-
-  describe('internals.validateReportTimeParams', function() {
-
-    describe('with all params valid', function() {
-
-      it('should return validated object', function() {
-        var params = internals.createReportTimeParams(),
-            validated = service.internals.validateReportTimeParams(params);
-        validated.should.have.keys([
-          'api_token',
-          'user_id',
-          'jobcode_id',
-          'duration_seconds',
-          'date'
-        ]);
-      });
-
-    });
-
-    describe('with invalid params', function() {
-      var params_to_test = ['api_token', 'user_id', 'jobcode_id', 'duration_seconds', 'date'];
-
-      params_to_test.forEach(function(param_name) {
-        describe('with missing ' + param_name, function() {
-
-          it('should throw error', function() {
-            internals.assertMissingParamFailsValidation(param_name);
+        it('should invoke API without error', function(done) {
+          service.reportTime(params, function(err, result) {
+            should.not.exist(err);
+            should.exist(result);
+            done();
           });
-
         });
+
+      });
+
+    });
+
+    describe('internals.validateReportTimeParams', function() {
+
+      describe('with all params valid', function() {
+
+        it('should return validated object', function() {
+          var params = internals.createReportTimeParams(),
+              validated = service.internals.validateReportTimeParams(params);
+          validated.should.have.keys([
+            'api_token',
+            'user_id',
+            'jobcode_id',
+            'duration_seconds',
+            'date'
+          ]);
+        });
+
+      });
+
+      describe('with invalid params', function() {
+        var params_to_test = ['api_token', 'user_id', 'jobcode_id', 'duration_seconds', 'date'];
+
+        params_to_test.forEach(function(param_name) {
+          describe('with missing ' + param_name, function() {
+
+            it('should throw error', function() {
+              internals.assertMissingParamFailsValidation(param_name);
+            });
+
+          });
+        });
+
+      });
+
+    });
+
+    describe('internals.createReportTimeRequestParams', function() {
+
+      describe('with valid params', function() {
+        var params;
+
+        beforeEach(function() {
+          params = internals.createReportTimeParams();
+        });
+
+        it('should return request params with POST to /timesheets', function() {
+          var req_params = service.internals.createReportTimeRequestParams(params);
+          req_params.should.eql({
+            api_token: params.api_token,
+            method: 'post',
+            endpoint: '/timesheets',
+            body_params: [
+              {
+                user_id: params.user_id,
+                jobcode_id: params.jobcode_id,
+                duration: params.duration_seconds,
+                date: params.date,
+                type: 'manual'
+              }
+            ]
+          });
+        });
+
       });
 
     });
 
   });
 
-  describe('internals.createReportTimeRequestParams', function() {
+  describe('getTimesheets', function() {
 
-    describe('with valid params', function() {
-      var params;
+    describe('exports.getTimesheets', function() {
 
-      beforeEach(function() {
-        params = internals.createReportTimeParams();
+      describe('with valid params', function() {
+        var params;
+
+        beforeEach(function() {
+          params = internals.createGetTimesheetsParams();
+        });
+
+        it('should invoke API without error', function(done) {
+          service.getTimesheets(params, function(err, result) {
+            should.not.exist(err);
+            should.exist(result);
+            done();
+          });
+        });
+
+        it('should return an object with timesheets mapped by user', function(done) {
+          service.getTimesheets(params, function(err, result) {
+            should.not.exist(err);
+            result.should.be.an('object');
+            done();
+          });
+        });
+
       });
 
-      it('should return request params with POST to /timesheets', function() {
-        var req_params = service.internals.createReportTimeRequestParams(params);
-        req_params.should.eql({
-          api_token: params.api_token,
-          method: 'post',
-          endpoint: '/timesheets',
-          body_params: [
-            {
-              user_id: params.user_id,
-              jobcode_id: params.jobcode_id,
-              duration: params.duration_seconds,
-              date: params.date,
-              type: 'manual'
+    });
+
+    describe('internals.validateGetTimesheetsParams', function() {
+
+      describe('with all params valid', function() {
+
+        it('should return validated object', function() {
+          var params = internals.createGetTimesheetsParams(),
+              validated = service.internals.validateGetTimesheetsParams(params);
+          validated.should.have.keys([
+            'api_token',
+            'user_ids',
+            'start_date',
+            'end_date'
+          ]);
+        });
+
+      });
+
+      describe('with invalid params', function() {
+        var params_to_test = [
+          'api_token',
+          'start_date',
+          'end_date'
+        ];
+
+        params_to_test.forEach(function(param_name) {
+          describe('with missing ' + param_name, function() {
+
+            it('should throw error', function() {
+              internals.assertMissingGetTimesheetsParamFailsValidation(param_name);
+            });
+
+          });
+        });
+
+      });
+
+    });
+
+    describe('internals.createGetTimesheetsRequestParams', function() {
+
+      describe('with complete and valid params', function() {
+        var params;
+
+        beforeEach(function() {
+          params = internals.createGetTimesheetsParams();
+        });
+
+        it('should return request params with GET to /timesheets', function() {
+          var req_params = service.internals.createGetTimesheetsParams(params);
+          req_params.should.eql({
+            api_token: params.api_token,
+            method: 'get',
+            endpoint: '/timesheets',
+            qs: {
+              user_ids: params.user_ids,
+              start_date: params.start_date,
+              end_date: params.end_date
             }
-          ]
+          });
+        });
+      });
+
+      describe('without user_ids', function() {
+        var params;
+
+        beforeEach(function() {
+          params = internals.createGetTimesheetsParams();
+          delete params.user_ids;
+        });
+
+        it('should return request params with GET to /timesheets', function() {
+          var req_params = service.internals.createGetTimesheetsParams(params);
+          req_params.should.eql({
+            api_token: params.api_token,
+            method: 'get',
+            endpoint: '/timesheets',
+            qs: {
+              start_date: params.start_date,
+              end_date: params.end_date
+            }
+          });
         });
       });
 
@@ -98,6 +221,16 @@ describe(__filename, function() {
   });
 
 });
+
+
+internals.createGetTimesheetsParams = function() {
+  return {
+    api_token: internals.VALID_API_TOKEN,
+    user_ids: [internals.TEST_USER_ID],
+    start_date: '2015-01-19',
+    end_date: '2015-01-25'
+  };
+};
 
 
 internals.createReportTimeParams = function() {
@@ -117,5 +250,15 @@ internals.assertMissingParamFailsValidation = function(param_name) {
 
   (function() {
     service.internals.validateReportTimeParams(params);
+  }).should.throw();
+};
+
+
+internals.assertMissingGetTimesheetsParamFailsValidation = function(param_name) {
+  var params = internals.createGetTimesheetsParams();
+  delete params[param_name];
+
+  (function() {
+    service.internals.validateGetTimesheetsParams(params);
   }).should.throw();
 };

--- a/tsheets-client.js
+++ b/tsheets-client.js
@@ -6,3 +6,8 @@ var service = require('./lib/tsheets-service.js');
 exports.reportTime = function(params, callback) {
   service.reportTime(params, callback);
 };
+
+
+exports.getTimesheets = function(params, callback) {
+  service.getTimesheets(params, callback);
+};


### PR DESCRIPTION
### `getTimesheets(params, callback)`

Gets timesheets for the specified user(s) for the provided time period.

**Params**

| Parameter | Description | Type | Required |
| --- | --- | --- | --- |
| api_token | TSheets API token to use for the request. | string | Yes |
| start_date | `YYYY-MM-DD` for the starting date. | string | Yes |
| end_date | `YYYY-MM-DD` for the end date. | string | Yes |
| user_ids | Array of TSheets user IDs to get timesheets for. | number[] | No |

---

```
    getTimesheets
      exports.getTimesheets
        with valid params
          ✓ should invoke API without error (1274ms)
          ✓ should return an object with timesheets mapped by user (1399ms)
      internals.validateGetTimesheetsParams
        with all params valid
          ✓ should return validated object 
        with invalid params
          with missing api_token
            ✓ should throw error 
          with missing start_date
            ✓ should throw error 
          with missing end_date
            ✓ should throw error 
      internals.createGetTimesheetsRequestParams
        with complete and valid params
          ✓ should return request params with GET to /timesheets 
        without user_ids
          ✓ should return request params with GET to /timesheets 
```
